### PR TITLE
Fix segfault when using rmw_get_node_names()

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1585,7 +1585,7 @@ static rmw_ret_t do_for_node_user_data (std::function<bool (const dds_builtintop
     auto f = [oper](const dds_builtintopic_participant_t& sample) -> bool {
                  void *ud;
                  size_t udsz;
-                 if (dds_qget_userdata (sample.qos, &ud, &udsz)) {
+                 if (dds_qget_userdata (sample.qos, &ud, &udsz) && ud != nullptr) {
                      /* CycloneDDS guarantees a null-terminated user data so we pretend it's a
                         string */
                      bool ret = oper (sample, static_cast<char *> (ud));


### PR DESCRIPTION
Sometimes dds_qget_userdata() returns true with a nullptr. It might be a good idea to revise its implementation.