### PR TITLE
Fix return of rmw_wait

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1264,7 +1264,7 @@ extern "C" rmw_ret_t rmw_wait (rmw_subscriptions_t *subs, rmw_guard_conditions_t
         ATTACH (CddsService, srvs, service, service.sub->rdcondh);
         ATTACH (CddsClient, cls, client, client.sub->rdcondh);
 #undef ATTACH
-        ws->trigs.reserve (nelems + 1);
+        ws->trigs.resize (nelems + 1);
     }
 
     const dds_duration_t timeout =
@@ -1305,7 +1305,7 @@ extern "C" rmw_ret_t rmw_wait (rmw_subscriptions_t *subs, rmw_guard_conditions_t
         ws->inuse = false;
     }
 
-    return (ws->trigs.size () == 0) ? RMW_RET_TIMEOUT : RMW_RET_OK;
+    return (ws->trigs.size () == 1) ? RMW_RET_TIMEOUT : RMW_RET_OK;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Misuse of std::vector resize as if it would leave any reserved entries
unchanged caused a misinterpretation of entries whenever the number of
triggering entities was larger than the number of triggering entities in
the preceding call to rmw_wait: these would all be mapped to the first
entity in the set.

If the waitset is reused from call to call and spurious events are
handled gracefully, this is recoverable; otherwise, no such luck.

Moreover, not accounting for a sentinel entry added to the list of
triggered entities means it would never return RMW_RET_TIMEOUT.

Signed-off-by: Erik Boasson <eb@ilities.com>