### PR TITLE
Don't retain all data in builtin-topics readers

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -300,7 +300,7 @@ static void ggcallback (dds_entity_t rd, void *varg)
     auto node_impl = static_cast<CddsNode *> (varg);
     void *msg = 0;
     dds_sample_info_t info;
-    while (dds_take_mask (rd, &msg, &info, 1, 1, DDS_ANY_SAMPLE_STATE | DDS_ANY_VIEW_STATE | DDS_NOT_ALIVE_DISPOSED_INSTANCE_STATE | DDS_NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) > 0) {
+    while (dds_take (rd, &msg, &info, 1, 1) > 0) {
         dds_return_loan (rd, &msg, 1);
     }
     if (rmw_trigger_guard_condition (node_impl->graph_guard_condition) != RMW_RET_OK) {


### PR DESCRIPTION
The built-in topics readers in the RMW node are currently not used for
anything other than triggering the guard condition.  All the query
functions just get their own data set from Cyclone.  Taking all samples
instead of just the not-alive ones reduces memory usage.