### PR TITLE
Various fixes for test failures and compatibility with Eloquent

### DIFF
--- a/rmw_cyclonedds_cpp/include/rmw_cyclonedds_cpp/serdes.hpp
+++ b/rmw_cyclonedds_cpp/include/rmw_cyclonedds_cpp/serdes.hpp
@@ -224,7 +224,9 @@ public:
     inline void deserialize (std::vector<bool>& x) {
         const uint32_t sz = deserialize32 ();
         x.resize (sz);
-        for (auto&& i : x) i = ((data + pos)[i] != 0);
+        for (size_t i = 0; i < sz; i++) {
+            x[i] = ((data + pos)[i] != 0);
+        }
         pos += sz;
     }
     template<class T, size_t S> inline void deserialize (std::array<T, S>& x) {

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1911,7 +1911,7 @@ static rmw_ret_t get_endpoint_names_and_types_by_node (const rmw_node_t *node, r
     return make_names_and_types (tptyp, tt, allocator);
 }
 
-static rmw_ret_t get_service_names_and_types_by_node (const rmw_node_t *node, rcutils_allocator_t *allocator, const char *node_name, const char *node_namespace, rmw_names_and_types_t *sntyp)
+static rmw_ret_t get_cs_names_and_types_by_node (const rmw_node_t *node, rcutils_allocator_t *allocator, const char *node_name, const char *node_namespace, rmw_names_and_types_t *sntyp, bool looking_for_services)
 {
     RET_WRONG_IMPLID (node);
     RET_NULL (allocator);
@@ -1963,7 +1963,7 @@ extern "C" rmw_ret_t rmw_get_topic_names_and_types (const rmw_node_t *node, rcut
 
 extern "C" rmw_ret_t rmw_get_service_names_and_types (const rmw_node_t *node, rcutils_allocator_t *allocator, rmw_names_and_types_t *sntyp)
 {
-    return get_service_names_and_types_by_node (node, allocator, nullptr, nullptr, sntyp);
+    return get_cs_names_and_types_by_node (node, allocator, nullptr, nullptr, sntyp, true);
 }
 
 extern "C" rmw_ret_t rmw_service_server_is_available (const rmw_node_t *node, const rmw_client_t *client, bool *is_available)
@@ -2037,5 +2037,10 @@ extern "C" rmw_ret_t rmw_get_publisher_names_and_types_by_node (const rmw_node_t
 
 extern "C" rmw_ret_t rmw_get_service_names_and_types_by_node (const rmw_node_t *node, rcutils_allocator_t *allocator, const char *node_name, const char *node_namespace, rmw_names_and_types_t *sntyp)
 {
-    return get_service_names_and_types_by_node (node, allocator, node_name, node_namespace, sntyp);
+    return get_cs_names_and_types_by_node (node, allocator, node_name, node_namespace, sntyp, true);
+}
+
+extern "C" rmw_ret_t rmw_get_client_names_and_types_by_node (const rmw_node_t *node, rcutils_allocator_t *allocator, const char *node_name, const char *node_namespace, rmw_names_and_types_t *sntyp)
+{
+    return get_cs_names_and_types_by_node (node, allocator, node_name, node_namespace, sntyp, false);
 }

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -785,7 +785,7 @@ static CddsPublisher *create_cdds_publisher (const rmw_node_t *node, const rosid
     std::string fqtopic_name = make_fqtopic (ros_topic_prefix, topic_name, "", qos_policies);
 
     auto sertopic = create_sertopic (fqtopic_name.c_str (), type_support->typesupport_identifier, create_message_type_support (type_support->data, type_support->typesupport_identifier), false);
-    if ((topic = dds_create_topic_arbitrary (gcdds.ppant, sertopic, nullptr, nullptr, nullptr)) < 0) {
+    if ((topic = dds_create_topic_arbitrary (node_impl->pp, sertopic, nullptr, nullptr, nullptr)) < 0) {
         RMW_SET_ERROR_MSG ("failed to create topic");
         goto fail_topic;
     }
@@ -957,7 +957,7 @@ static CddsSubscription *create_cdds_subscription (const rmw_node_t *node, const
     std::string fqtopic_name = make_fqtopic (ros_topic_prefix, topic_name, "", qos_policies);
 
     auto sertopic = create_sertopic (fqtopic_name.c_str (), type_support->typesupport_identifier, create_message_type_support (type_support->data, type_support->typesupport_identifier), false);
-    if ((topic = dds_create_topic_arbitrary (gcdds.ppant, sertopic, nullptr, nullptr, nullptr)) < 0) {
+    if ((topic = dds_create_topic_arbitrary (node_impl->pp, sertopic, nullptr, nullptr, nullptr)) < 0) {
         RMW_SET_ERROR_MSG ("failed to create topic");
         goto fail_topic;
     }
@@ -1535,11 +1535,11 @@ static rmw_ret_t rmw_init_cs (CddsCS *cs, const rmw_node_t *node, const rosidl_s
     auto sub_st = create_sertopic (subtopic_name.c_str (), type_support->typesupport_identifier, sub_type_support, true);
 
     dds_qos_t *qos;
-    if ((pubtopic = dds_create_topic_arbitrary (gcdds.ppant, pub_st, nullptr, nullptr, nullptr)) < 0) {
+    if ((pubtopic = dds_create_topic_arbitrary (node_impl->pp, pub_st, nullptr, nullptr, nullptr)) < 0) {
         RMW_SET_ERROR_MSG ("failed to create topic");
         goto fail_pubtopic;
     }
-    if ((subtopic = dds_create_topic_arbitrary (gcdds.ppant, sub_st, nullptr, nullptr, nullptr)) < 0) {
+    if ((subtopic = dds_create_topic_arbitrary (node_impl->pp, sub_st, nullptr, nullptr, nullptr)) < 0) {
         RMW_SET_ERROR_MSG ("failed to create topic");
         goto fail_subtopic;
     }

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -31,6 +31,7 @@
 #include "rmw/get_service_names_and_types.h"
 #include "rmw/get_topic_names_and_types.h"
 #include "rmw/get_node_info_and_types.h"
+#include "rmw/validate_node_name.h"
 #include "rmw/rmw.h"
 #include "rmw/sanity_checks.h"
 
@@ -359,7 +360,12 @@ extern "C" rmw_node_t *rmw_create_node (rmw_context_t *context, const char *name
     RET_NULL_X (namespace_, return nullptr);
     (void) domain_id;
     (void) security_options;
-
+    rmw_ret_t ret;
+    int dummy_validation_result;
+    size_t dummy_invalid_index;
+    if ((ret = rmw_validate_node_name (name, &dummy_validation_result, &dummy_invalid_index)) != RMW_RET_OK) {
+        return nullptr;
+    }
     dds_qos_t *qos = dds_create_qos ();
     std::string user_data = get_node_user_data (name, namespace_);
     dds_qset_userdata (qos, user_data.c_str (), user_data.size ());
@@ -1813,6 +1819,13 @@ static rmw_ret_t get_endpoint_names_and_types_by_node (const rmw_node_t *node, r
     if (ret != RMW_RET_OK) {
         return ret;
     }
+    if (node_name) {
+        int dummy_validation_result;
+        size_t dummy_invalid_index;
+        if ((ret = rmw_validate_node_name (node_name, &dummy_validation_result, &dummy_invalid_index)) != RMW_RET_OK) {
+            return ret;
+        }
+    }
     std::set<dds_builtintopic_guid_t> guids;
     if (node_name != nullptr && (ret = get_node_guids (node_name, node_namespace, guids)) != RMW_RET_OK) {
         return ret;
@@ -1850,6 +1863,13 @@ static rmw_ret_t get_service_names_and_types_by_node (const rmw_node_t *node, rc
     rmw_ret_t ret = rmw_names_and_types_check_zero (sntyp);
     if (ret != RMW_RET_OK) {
         return ret;
+    }
+    if (node_name) {
+        int dummy_validation_result;
+        size_t dummy_invalid_index;
+        if ((ret = rmw_validate_node_name (node_name, &dummy_validation_result, &dummy_invalid_index)) != RMW_RET_OK) {
+            return ret;
+        }
     }
     std::set<dds_builtintopic_guid_t> guids;
     if (node_name != nullptr && (ret = get_node_guids (node_name, node_namespace, guids)) != RMW_RET_OK) {

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1481,7 +1481,7 @@ extern "C" rmw_ret_t rmw_send_request (const rmw_client_t *client, const void *r
     auto info = static_cast<CddsClient *> (client->data);
     cdds_request_header_t header;
     header.guid = info->client.pub->pubiid;
-    header.seq = *sequence_id = next_request_id++;
+    header.seq = *sequence_id = ++next_request_id;
     return rmw_send_response_request (&info->client, header, ros_request);
 }
 

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1863,7 +1863,15 @@ static rmw_ret_t get_node_guids (const char *node_name, const char *node_namespa
                     }
                     return true; /* do keep looking - what if there are many? */
                 };
-    return do_for_node_user_data (oper);
+    rmw_ret_t ret = do_for_node_user_data (oper);
+    if (ret != RMW_RET_OK) {
+        return ret;
+    } else if (guids.size () == 0) {
+        /* It appears the get_..._by_node operations are supposed to return ERROR if no such node exists */
+        return RMW_RET_ERROR;
+    } else {
+        return RMW_RET_OK;
+    }
 }
 
 static rmw_ret_t get_endpoint_names_and_types_by_node (const rmw_node_t *node, rcutils_allocator_t *allocator, const char *node_name, const char *node_namespace, bool no_demangle, rmw_names_and_types_t *tptyp, bool subs, bool pubs)


### PR DESCRIPTION
This set of commits addresses a number of test failures and adds get_client_names_and_types_by_node for compatibility with current master/Eloquent.