### PR TITLE
Address a few items

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -687,12 +687,16 @@ static dds_qos_t * create_readwrite_qos(
     case RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT:
     case RMW_QOS_POLICY_HISTORY_UNKNOWN:
     case RMW_QOS_POLICY_HISTORY_KEEP_LAST:
-      if (qos_policies->depth > INT32_MAX) {
-        RMW_SET_ERROR_MSG("unsupported history depth");
-        dds_delete_qos(qos);
-        return nullptr;
+      if (qos_policies->depth == RMW_QOS_POLICY_DEPTH_SYSTEM_DEFAULT) {
+        dds_qset_history(qos, DDS_HISTORY_KEEP_LAST, 1);
+      } else {
+        if (qos_policies->depth < 1 || qos_policies->depth > INT32_MAX) {
+          RMW_SET_ERROR_MSG("unsupported history depth");
+          dds_delete_qos(qos);
+          return nullptr;
+        }
+        dds_qset_history(qos, DDS_HISTORY_KEEP_LAST, static_cast<uint32_t>(qos_policies->depth));
       }
-      dds_qset_history(qos, DDS_HISTORY_KEEP_LAST, static_cast<uint32_t>(qos_policies->depth));
       break;
     case RMW_QOS_POLICY_HISTORY_KEEP_ALL:
       dds_qset_history(qos, DDS_HISTORY_KEEP_ALL, DDS_LENGTH_UNLIMITED);


### PR DESCRIPTION
* RMW_QOS_POLICY_DEPTH_SYSTEM_DEFAULT was not handled, causing some failures in reader/writer creation;
* waiting on an "empty" waiset behaves differently, attaching an otherwise unused guard condition to the RMW wait sets brings Cyclone RMW behaviour in line with RCL expectations;
* implement ``rmw_take_event`` — the underlying events are not yet generated by Cyclone, but the interfaces to retrieve the data are available, so it is better to implement it properly