### PR TITLE
Interoperate with other DDS implementations

### DIFF
--- a/rmw_cyclonedds_cpp/include/rmw_cyclonedds_cpp/serdata.hpp
+++ b/rmw_cyclonedds_cpp/include/rmw_cyclonedds_cpp/serdata.hpp
@@ -30,9 +30,11 @@ struct sertopic_rmw : ddsi_sertopic
 {
   CddsTypeSupport type_support;
   bool is_request_header;
+#if !DDSI_SERTOPIC_HAS_TOPICKIND_NO_KEY
   std::string cpp_name;
   std::string cpp_type_name;
   std::string cpp_name_type_name;
+#endif
 };
 
 struct serdata_rmw : ddsi_serdata

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1330,70 +1330,70 @@ extern "C" rmw_ret_t rmw_take_event(
   RET_NULL(event_info);
   switch (event_handle->event_type) {
     case RMW_EVENT_LIVELINESS_CHANGED: {
-      auto ei = static_cast<rmw_liveliness_changed_status_t *>(event_info);
-      auto sub = static_cast<CddsSubscription *>(event_handle->data);
-      dds_liveliness_changed_status_t st;
-      if (dds_get_liveliness_changed_status (sub->subh, &st) < 0) {
-        *taken = false;
-        return RMW_RET_ERROR;
-      } else {
-        ei->alive_count = static_cast<int32_t>(st.alive_count);
-        ei->not_alive_count = static_cast<int32_t>(st.not_alive_count);
-        ei->alive_count_change = st.alive_count_change;
-        ei->not_alive_count_change = st.not_alive_count_change;
-        *taken = true;
-        return RMW_RET_OK;
+        auto ei = static_cast<rmw_liveliness_changed_status_t *>(event_info);
+        auto sub = static_cast<CddsSubscription *>(event_handle->data);
+        dds_liveliness_changed_status_t st;
+        if (dds_get_liveliness_changed_status(sub->subh, &st) < 0) {
+          *taken = false;
+          return RMW_RET_ERROR;
+        } else {
+          ei->alive_count = static_cast<int32_t>(st.alive_count);
+          ei->not_alive_count = static_cast<int32_t>(st.not_alive_count);
+          ei->alive_count_change = st.alive_count_change;
+          ei->not_alive_count_change = st.not_alive_count_change;
+          *taken = true;
+          return RMW_RET_OK;
+        }
       }
-    }
 
     case RMW_EVENT_REQUESTED_DEADLINE_MISSED: {
-      auto ei = static_cast<rmw_requested_deadline_missed_status_t *>(event_info);
-      auto sub = static_cast<CddsSubscription *>(event_handle->data);
-      dds_requested_deadline_missed_status_t st;
-      if (dds_get_requested_deadline_missed_status (sub->subh, &st) < 0) {
-        *taken = false;
-        return RMW_RET_ERROR;
-      } else {
-        ei->total_count = static_cast<int32_t>(st.total_count);
-        ei->total_count_change = st.total_count_change;
-        *taken = true;
-        return RMW_RET_OK;
+        auto ei = static_cast<rmw_requested_deadline_missed_status_t *>(event_info);
+        auto sub = static_cast<CddsSubscription *>(event_handle->data);
+        dds_requested_deadline_missed_status_t st;
+        if (dds_get_requested_deadline_missed_status(sub->subh, &st) < 0) {
+          *taken = false;
+          return RMW_RET_ERROR;
+        } else {
+          ei->total_count = static_cast<int32_t>(st.total_count);
+          ei->total_count_change = st.total_count_change;
+          *taken = true;
+          return RMW_RET_OK;
+        }
       }
-    }
 
     case RMW_EVENT_LIVELINESS_LOST: {
-      auto ei = static_cast<rmw_requested_deadline_missed_status_t *>(event_info);
-      auto pub = static_cast<CddsPublisher *>(event_handle->data);
-      dds_requested_deadline_missed_status_t st;
-      if (dds_get_requested_deadline_missed_status (pub->pubh, &st) < 0) {
-        *taken = false;
-        return RMW_RET_ERROR;
-      } else {
-        ei->total_count = static_cast<int32_t>(st.total_count);
-        ei->total_count_change = st.total_count_change;
-        *taken = true;
-        return RMW_RET_OK;
+        auto ei = static_cast<rmw_requested_deadline_missed_status_t *>(event_info);
+        auto pub = static_cast<CddsPublisher *>(event_handle->data);
+        dds_requested_deadline_missed_status_t st;
+        if (dds_get_requested_deadline_missed_status(pub->pubh, &st) < 0) {
+          *taken = false;
+          return RMW_RET_ERROR;
+        } else {
+          ei->total_count = static_cast<int32_t>(st.total_count);
+          ei->total_count_change = st.total_count_change;
+          *taken = true;
+          return RMW_RET_OK;
+        }
       }
-    }
 
     case RMW_EVENT_OFFERED_DEADLINE_MISSED: {
-      auto ei = static_cast<rmw_offered_deadline_missed_status_t *>(event_info);
-      auto pub = static_cast<CddsPublisher *>(event_handle->data);
-      dds_offered_deadline_missed_status_t st;
-      if (dds_get_offered_deadline_missed_status (pub->pubh, &st) < 0) {
-        *taken = false;
-        return RMW_RET_ERROR;
-      } else {
-        ei->total_count = static_cast<int32_t>(st.total_count);
-        ei->total_count_change = st.total_count_change;
-        *taken = true;
-        return RMW_RET_OK;
+        auto ei = static_cast<rmw_offered_deadline_missed_status_t *>(event_info);
+        auto pub = static_cast<CddsPublisher *>(event_handle->data);
+        dds_offered_deadline_missed_status_t st;
+        if (dds_get_offered_deadline_missed_status(pub->pubh, &st) < 0) {
+          *taken = false;
+          return RMW_RET_ERROR;
+        } else {
+          ei->total_count = static_cast<int32_t>(st.total_count);
+          ei->total_count_change = st.total_count_change;
+          *taken = true;
+          return RMW_RET_OK;
+        }
       }
-    }
 
     case RMW_EVENT_INVALID: {
-      break;
-    }
+        break;
+      }
   }
   *taken = false;
   return RMW_RET_ERROR;

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -2242,7 +2242,7 @@ static rmw_ret_t get_endpoint_names_and_types_by_node(
     std::regex("^" + std::string(ros_topic_prefix) + "(/.*)", std::regex::extended);
   const auto re_typ = std::regex("^(.*::)dds_::(.*)_$", std::regex::extended);
   const auto filter_and_map =
-    [re_tp, re_typ, guids, node_name](const dds_builtintopic_endpoint_t & sample,
+    [re_tp, re_typ, guids, node_name, no_demangle](const dds_builtintopic_endpoint_t & sample,
       std::string & topic_name, std::string & type_name) -> bool {
       std::cmatch cm_tp, cm_typ;
       if (node_name != nullptr && guids.count(sample.participant_key) == 0) {
@@ -2253,10 +2253,14 @@ static rmw_ret_t get_endpoint_names_and_types_by_node(
         {
           return false;
         } else {
-          std::string demangled_type = std::regex_replace(std::string(cm_typ[1]), std::regex(
-                "::"), "/");
           topic_name = std::string(cm_tp[1]);
-          type_name = std::string(demangled_type) + std::string(cm_typ[2]);
+          if (no_demangle) {
+            type_name = std::string(type_name);
+          } else {
+            std::string demangled_type = std::regex_replace(std::string(cm_typ[1]), std::regex(
+                  "::"), "/");
+            type_name = std::string(demangled_type) + std::string(cm_typ[2]);
+          }
           return true;
         }
       }

--- a/rmw_cyclonedds_cpp/src/serdata.cpp
+++ b/rmw_cyclonedds_cpp/src/serdata.cpp
@@ -336,6 +336,9 @@ static const struct ddsi_serdata_ops serdata_rmw_ops = {
 static void sertopic_rmw_free(struct ddsi_sertopic * tpcmn)
 {
   struct sertopic_rmw * tp = static_cast<struct sertopic_rmw *>(tpcmn);
+#if DDSI_SERTOPIC_HAS_TOPICKIND_NO_KEY
+  ddsi_sertopic_fini(tpcmn);
+#endif
   delete tp;
 }
 
@@ -421,6 +424,11 @@ struct sertopic_rmw * create_sertopic(
   void * type_support, bool is_request_header)
 {
   struct sertopic_rmw * st = new struct sertopic_rmw;
+#if DDSI_SERTOPIC_HAS_TOPICKIND_NO_KEY
+  std::string type_name = get_type_name(type_support_identifier, type_support);
+  ddsi_sertopic_init(static_cast<struct ddsi_sertopic *>(st), topicname,
+    type_name.c_str(), &sertopic_rmw_ops, &serdata_rmw_ops, true);
+#else
   memset(st, 0, sizeof(struct ddsi_sertopic));
   st->cpp_name = std::string(topicname);
   st->cpp_type_name = get_type_name(type_support_identifier, type_support);
@@ -433,7 +441,7 @@ struct sertopic_rmw * create_sertopic(
   st->type_name = const_cast<char *>(st->cpp_type_name.c_str());
   st->iid = ddsi_iid_gen();
   ddsrt_atomic_st32(&st->refc, 1);
-
+#endif
   st->type_support.typesupport_identifier_ = type_support_identifier;
   st->type_support.type_support_ = type_support;
   st->is_request_header = is_request_header;

--- a/rmw_cyclonedds_cpp/src/serdes.cpp
+++ b/rmw_cyclonedds_cpp/src/serdes.cpp
@@ -22,7 +22,7 @@ cycser::cycser(std::vector<unsigned char> & dst_)
   dst.reserve(4);
   /* FIXME: hard code to little endian ... and ignoring endianness in deser */
   dst.push_back(0);
-  dst.push_back(3);
+  dst.push_back(1);
   /* options: */
   dst.push_back(0);
   dst.push_back(0);


### PR DESCRIPTION
This pull request address two interoperability issues:
* The serialization format was set incorrectly (to parameterized CDR ...) — oops;
* The rest-of-the-world incorrectly (for DDS, not necessarily for ROS2) uses the "NO_KEY" variants for reader/writer GUIDs whereas Cyclone stuck with the "WITH_KEY" variant. This way, interop is never going to work properly, and so Cyclone has submitted to the tyranny of the majority. This necessitated a change in the interfaces for custom topic implementations. The code is source-compatible with both versions of the interfaces in Cyclone.
I'm not sure this fixes all issues, but it is certainly sufficient to make things start working.

The reset is dull details.