### PR TITLE
Replace cyclonedds by CycloneDDS for colcon

### DIFF
--- a/rmw_cyclonedds_cpp/package.xml
+++ b/rmw_cyclonedds_cpp/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
 
-  <build_depend>cyclonedds</build_depend>
+  <build_depend>CycloneDDS</build_depend>
   <build_depend>cyclonedds_cmake_module</build_depend>
   <build_depend>rcutils</build_depend>
   <build_depend>rmw</build_depend>
@@ -20,7 +20,7 @@
   <build_depend>rosidl_typesupport_introspection_c</build_depend>
   <build_depend>rosidl_typesupport_introspection_cpp</build_depend>
 
-  <build_export_depend>cyclonedds</build_export_depend>
+  <build_export_depend>CycloneDDS</build_export_depend>
   <build_export_depend>cyclonedds_cmake_module</build_export_depend>
   <build_export_depend>rcutils</build_export_depend>
   <build_export_depend>rmw</build_export_depend>


### PR DESCRIPTION
Commit 1200bfd109e4e21ff572ce0c6205cb6c2e247edc in Cyclone DDS changed
the setting of the project name to use a string literal.  That change
affects the capitalization of the name under which colcon looks for
Cyclone, and this commit changes the dependency specification to match.

Signed-off-by: Erik Boasson <eb@ilities.com>