### PR TITLE
Prepare rmw_cyclonedds for release in ROS 2

### DIFF
--- a/cyclonedds_cmake_module/package.xml
+++ b/cyclonedds_cmake_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>cyclonedds_cmake_module</name>
-  <version>0.0.1</version>
+  <version>0.4.0</version>
   <description>Provide CMake module to find Eclipse CycloneDDS.</description>
   <maintainer email="erik.boasson@adlinktech.com">Erik Boasson</maintainer>
   <license>Apache License 2.0</license>

--- a/rmw_cyclonedds_cpp/package.xml
+++ b/rmw_cyclonedds_cpp/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
 
-  <build_depend>CycloneDDS</build_depend>
+  <build_depend>cyclonedds</build_depend>
   <build_depend>cyclonedds_cmake_module</build_depend>
   <build_depend>rcutils</build_depend>
   <build_depend>rmw</build_depend>
@@ -20,7 +20,7 @@
   <build_depend>rosidl_typesupport_introspection_c</build_depend>
   <build_depend>rosidl_typesupport_introspection_cpp</build_depend>
 
-  <build_export_depend>CycloneDDS</build_export_depend>
+  <build_export_depend>cyclonedds</build_export_depend>
   <build_export_depend>cyclonedds_cmake_module</build_export_depend>
   <build_export_depend>rcutils</build_export_depend>
   <build_export_depend>rmw</build_export_depend>


### PR DESCRIPTION
In order for Bloom to release the packages in this repository, they must all carry the same version number.

Additionally, tagging that version in Git makes that process significantly easier, and is highly recommended when you're ready to release these packages.