### PR TITLE
Address CMake and uncrustify linter violations

### DIFF
--- a/rmw_cyclonedds_cpp/CMakeLists.txt
+++ b/rmw_cyclonedds_cpp/CMakeLists.txt
@@ -33,7 +33,7 @@ find_package(ament_cmake_ros REQUIRED)
 
 find_package(rcutils REQUIRED)
 
-if (CYCLONEDDS_FROM_SOURCE)
+if(CYCLONEDDS_FROM_SOURCE)
   message("Building CycloneDDS from source")
   find_package(cyclonedds_vendor REQUIRED)
 else()

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -69,8 +69,8 @@
 #define REPORT_BLOCKED_REQUESTS 0
 
 #define RET_ERR_X(msg, code) do {RMW_SET_ERROR_MSG(msg); code;} while (0)
-#define RET_NULL_X(var, code) do {if (!var) RET_ERR_X (#var " is null", code);} while (0)
-#define RET_ALLOC_X(var, code) do {if (!var) RET_ERR_X ("failed to allocate " #var, code); \
+#define RET_NULL_X(var, code) do {if (!var) {RET_ERR_X(#var " is null", code);}} while (0)
+#define RET_ALLOC_X(var, code) do {if (!var) {RET_ERR_X("failed to allocate " #var, code);} \
 } while (0)
 #define RET_WRONG_IMPLID_X(var, code) do { \
     RET_NULL_X(var, code); \
@@ -2571,7 +2571,7 @@ static rmw_ret_t get_cs_names_and_types_by_node(
   const auto re_typ = std::regex("^(.*::)dds_::(.*)_(Response|Request)_$", std::regex::extended);
   const auto filter_and_map =
     [re_tp, re_typ, guids, node_name,
-      looking_for_services](const dds_builtintopic_endpoint_t & sample, std::string & topic_name,
+    looking_for_services](const dds_builtintopic_endpoint_t & sample, std::string & topic_name,
       std::string & type_name) -> bool {
       std::cmatch cm_tp, cm_typ;
       if (node_name != nullptr && guids.count(sample.participant_key) == 0) {


### PR DESCRIPTION
```
Failed: rmw_cyclonedds_cpp.lint_cmake.whitespace/extra (CMakeLists.txt:36)
Extra spaces between 'if' and its ()
```

```
Failed: rmw_cyclonedds_cpp.uncrustify.src/rmw_node.cpp
Diff with 10 lines

--- src/rmw_node.cpp
+++ src/rmw_node.cpp.uncrustify
@@ -72,2 +72,2 @@
-#define RET_NULL_X(var, code) do {if (!var) RET_ERR_X (#var " is null", code);} while (0)
-#define RET_ALLOC_X(var, code) do {if (!var) RET_ERR_X ("failed to allocate " #var, code); \
+#define RET_NULL_X(var, code) do {if (!var) {RET_ERR_X(#var " is null", code);}} while (0)
+#define RET_ALLOC_X(var, code) do {if (!var) {RET_ERR_X("failed to allocate " #var, code);} \
@@ -2574 +2574 @@
-      looking_for_services](const dds_builtintopic_endpoint_t & sample, std::string & topic_name,
+    looking_for_services](const dds_builtintopic_endpoint_t & sample, std::string & topic_name,
```